### PR TITLE
Fix dependency issue preventing dev server from starting

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "gh-pages": "^0.11.0",
     "html-webpack-plugin": "^2.21.0",
-    "html-webpack-template": "^5.0.0",
+    "html-webpack-template": "5.0.0",
     "isparta-loader": "^2.0.0",
     "karma": "^1.0.0",
     "karma-coverage": "^1.0.0",


### PR DESCRIPTION
- This PR resolves issue: https://github.com/survivejs/react-boilerplate/issues/5
- Issue Summary: `npm start` with html-webpack-template@5.1.0 results in "TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined"
- Cause: html-webpack-template@5.1.0 does not appear to be backward compatible
  with html-webpack-template@5.0.0 which is specified in the
  package.json
- Proposal: specify the version exactly instead of using "^" or "compatible with version" dependency prefix 
